### PR TITLE
[IMP] odoo-edi: Extend raw importer regex to accept "_" for model names

### DIFF
--- a/addons/edi/models/edi_raw_document.py
+++ b/addons/edi/models/edi_raw_document.py
@@ -14,7 +14,7 @@ OPTIONS = {
 
 TRIAL_COUNT = 10
 
-MODEL_PATTERN = re.compile(r'.*?(?P<model>([a-z]+\.)+[a-z]+)$')
+MODEL_PATTERN = re.compile(r'.*?(?P<model>([a-z]+\_?[a-z]+\.)+([a-z]+\_?[a-z]+))$')
 
 
 class TrialImport(Exception):


### PR DESCRIPTION
User-story: 11723
Signed-off-by: Robert Smith <robert.smith@unipart.io>