### PR TITLE
[FIX] odoo-edi: Fix to allow background EDI docs for non-admin

### DIFF
--- a/addons/edi_stock/models/stock_picking.py
+++ b/addons/edi_stock/models/stock_picking.py
@@ -40,5 +40,5 @@ class StockPicking(models.Model):
         res = super().action_done()
         self.mapped('picking_type_id').filtered(
             lambda x: x.edi_pick_report_autoemit
-        ).action_edi_pick_report()
+        ).sudo().action_edi_pick_report()
         return res


### PR DESCRIPTION
Allows non-admin users to validate pickings for picking types that autoemit a pick report.

Story/12373

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>