### PR TITLE
[FIX] edi: Make assertAttachment() work for 0-length empty attachments

### DIFF
--- a/addons/edi/tests/common.py
+++ b/addons/edi/tests/common.py
@@ -139,7 +139,7 @@ class EdiCase(common.SavepointCase):
         try:
             maxDiff = self.maxDiff
             self.maxDiff = None
-            self.assertEqual(decode(base64.b64decode(attachment.datas)),
+            self.assertEqual(decode(base64.b64decode(attachment.datas or b"")),
                              decode(data))
         finally:
             self.maxDiff = maxDiff


### PR DESCRIPTION
Odoo stores 0-length attachments as NULL in the database, and reads them
back as `False`.

Signed-off-by: Sean Quah <sean.quah@unipart.io>