### PR TITLE
[FIX] public/odoo-edi: Handle empty attachments in connections.

### DIFF
--- a/addons/edi/models/edi_connection_local.py
+++ b/addons/edi/models/edi_connection_local.py
@@ -165,7 +165,7 @@ class EdiConnectionLocal(models.AbstractModel):
             # Write file with temporary filename
             _logger.info("%s writing %s", transfer.gateway_id.name, filepath)
             temppath = filepath.with_name('.%s~' % uuid.uuid4().hex)
-            temppath.write_bytes(base64.b64decode(attachment.datas))
+            temppath.write_bytes(base64.b64decode(attachment.datas or b''))
 
             # Rename temporary file
             temppath.rename(filepath)

--- a/addons/edi/models/edi_connection_sftp.py
+++ b/addons/edi/models/edi_connection_sftp.py
@@ -158,7 +158,7 @@ class EdiConnectionSFTP(models.AbstractModel):
             temppath = os.path.join(path.path, ('.%s~' % uuid.uuid4().hex))
             filepath = os.path.join(path.path, attachment.datas_fname)
             _logger.info("%s sending %s", transfer.gateway_id.name, filepath)
-            data = base64.b64decode(attachment.datas)
+            data = base64.b64decode(attachment.datas or b'')
             conn.file(temppath, mode='wb').write(data)
 
             # Rename temporary file


### PR DESCRIPTION
story/13878

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

Third party systems may expect to be sent an empty file in some
circumstances.  This patch amends the local filesystem and SFTP
connections to handle empty attachments.