### PR TITLE
[FIX] edi: Fix message_post to return ids when called from the desktop UI

### DIFF
--- a/addons/edi/models/mail_thread.py
+++ b/addons/edi/models/mail_thread.py
@@ -13,6 +13,7 @@ class MailThread(models.AbstractModel):
     _inherit = 'mail.thread'
 
     @api.multi
+    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *args, **kwargs):
         """Post message"""
         if self._context.get('tracking_disable'):


### PR DESCRIPTION
This follows the convention of other message_post definitions

User-story: 14483