### PR TITLE
[FIX] edi_stock: Remove required attr of pick_id on edi.pick.report.r…

### DIFF
--- a/addons/edi_stock/models/edi_pick_report_record.py
+++ b/addons/edi_stock/models/edi_pick_report_record.py
@@ -37,7 +37,7 @@ class EdiPickReportRecord(models.Model):
     _description = "Stock Transfer Report"
 
     pick_id = fields.Many2one('stock.picking', string="Transfer",
-                              required=True, readonly=True, index=True)
+                              readonly=True, index=True)
 
     _sql_constraints = [('doc_name_uniq', 'unique (doc_id, name)',
                          "Each name may appear at most once per document")]


### PR DESCRIPTION
…ecord

Pick refactoring can delete picks related to edi records, which leads
to this constraint being violated.

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 14678