### PR TITLE
[ADD] odoo-edi: Optionally enforce EDI document names

### DIFF
--- a/addons/edi/models/__init__.py
+++ b/addons/edi/models/__init__.py
@@ -24,3 +24,5 @@ from . import edi_partner_record
 from . import edi_partner_tutorial
 from . import edi_raw_document
 from . import edi_raw_record
+
+from . import ir_attachment

--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -82,6 +82,11 @@ class EdiDocumentType(models.Model):
                                help="End document execution immediately on error",
                                default=True)
 
+    # optionally enforce document name globs
+    enforce_filename = fields.Boolean(string="Enforce Document Filenames",
+                                  help="Enforce document filenames follow glob pattern",
+                                  default=False)
+
     _sql_constraints = [('model_uniq', 'unique (model_id)',
                          "The document model must be unique")]
 

--- a/addons/edi/models/ir_attachment.py
+++ b/addons/edi/models/ir_attachment.py
@@ -1,0 +1,32 @@
+from odoo import api, models
+from odoo.exceptions import ValidationError
+from odoo.tools.translate import _
+
+import fnmatch
+
+
+class IrAttachment(models.Model):
+
+    _inherit = "ir.attachment"
+
+    @api.constrains("res_model")
+    def check_filename(self):
+        """Validates attachment filename against the format defined in 'glob'"""
+        EdiDocument = self.env["edi.document"]
+        EdiGatewayPath = self.env["edi.gateway.path"]
+        edi_document_attachments = self.filtered(lambda a: a.res_model == "edi.document")
+        for attachment in edi_document_attachments:
+            doc = EdiDocument.browse(attachment.res_id)
+
+            if doc.doc_type_id.enforce_filename:
+                recs = EdiGatewayPath.search([("doc_type_ids", "=", doc.doc_type_id.id)])
+                if recs:
+                    globs = recs.mapped("glob")
+                    for input in doc.input_ids:
+                        passed = False
+                        for glob in globs:
+                            if fnmatch.fnmatch(input.datas_fname, glob):
+                                passed = True
+                                break
+                        if not passed:
+                            raise ValidationError(_("Invalid filename when trying to attach."))

--- a/addons/edi/views/edi_document_type_views.xml
+++ b/addons/edi/views/edi_document_type_views.xml
@@ -20,6 +20,7 @@
 		<field name="model_id"/>
 		<field name="rec_type_ids" widget="many2many_tags"/>
 		<field name="sequence_id"/>
+		<field name="enforce_filename"/>
 	      </group>
 	      <group name="issues" string="Issues">
 		<field name="project_id"/>


### PR DESCRIPTION
Add enforce_filename field to EdiDocumentType, and extended ir.attachment to check filename matches file type glob.

User-story: 14199