### PR TITLE
[FIX] edi: Added sudo calls to allow EDI to progress

### DIFF
--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -315,6 +315,8 @@ class EdiDocument(models.Model):
         Parse input attachments and create corresponding EDI records.
         """
         self.ensure_one()
+        # TODO Consider a better way of getting around the permissions
+        self = self.sudo()
         # Lock document
         self.lock_for_action()
         # Check document state
@@ -350,6 +352,8 @@ class EdiDocument(models.Model):
     def action_unprepare(self):
         """Return Prepared document to Draft state"""
         self.ensure_one()
+        # TODO Consider a better way of getting around the permissions
+        self = self.sudo()
         # Lock document
         self.lock_for_action()
         # Check document state
@@ -376,6 +380,8 @@ class EdiDocument(models.Model):
         Parse EDI records and update database.
         """
         self.ensure_one()
+        # TODO Consider a better way of getting around the permissions
+        self = self.sudo()
         # Lock document
         self.lock_for_action()
         # Automatically prepare document if needed
@@ -416,6 +422,8 @@ class EdiDocument(models.Model):
     def action_cancel(self):
         """Cancel document"""
         self.ensure_one()
+        # TODO Consider a better way of getting around the permissions
+        self = self.sudo()
         # Lock document
         self.lock_for_action()
         # Check document state

--- a/addons/edi/models/edi_raw_document.py
+++ b/addons/edi/models/edi_raw_document.py
@@ -98,6 +98,7 @@ class EdiRawDocument(models.AbstractModel):
             # Most likely an unrecognised column heading
             raise UserError(_("Unrecognised header \"%s\"") % e.args[0]) from e
         finally:
+            # sudo() added to action_prepare to allow this
             importer.unlink()
 
         # Raise any errors from the import


### PR DESCRIPTION
Added sudo calls to prepare, execute and cancel actions to allow an EDI document to progress through the relevants steps.

N.B. We may need to review and come up with a better solution to flagrant use of sudo.

Story/X606

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>