### PR TITLE
Story #910 Standard Interfaces - Port Item Master

### DIFF
--- a/addons/edi/models/__init__.py
+++ b/addons/edi/models/__init__.py
@@ -23,5 +23,4 @@ from . import edi_partner_document
 from . import edi_partner_record
 from . import edi_raw_document
 from . import edi_raw_record
-
 from . import ir_attachment

--- a/addons/edi/models/__init__.py
+++ b/addons/edi/models/__init__.py
@@ -23,3 +23,5 @@ from . import edi_partner_document
 from . import edi_partner_record
 from . import edi_raw_document
 from . import edi_raw_record
+
+from . import ir_attachment

--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -71,12 +71,18 @@ class EdiDocumentType(models.Model):
 
     # Sequence for generating document names
     sequence_id = fields.Many2one(
-        "ir.sequence", string="Document Name Sequence", required=True, default=_default_sequence_id
+        "ir.sequence",
+        string="Document Name Sequence",
+        required=True,
+        default=_default_sequence_id,
     )
 
     # Issue tracker used for asynchronously reporting errors
     project_id = fields.Many2one(
-        "project.project", string="Issue Tracker", required=True, default=_default_project_id
+        "project.project",
+        string="Issue Tracker",
+        required=True,
+        default=_default_project_id,
     )
 
     # Control visibility in the UI.
@@ -85,11 +91,15 @@ class EdiDocumentType(models.Model):
     )
 
     # Optionally enforce filename globs
-    enforce_filename = fields.Boolean(string="Enforce Document Filenames",
-                                  help="Enforce document filenames follow glob pattern",
-                                  default=False)
+    enforce_filename = fields.Boolean(
+        string="Enforce Document Filenames",
+        help="Enforce document filenames follow glob pattern",
+        default=False,
+    )
 
-    _sql_constraints = [("model_uniq", "unique (model_id)", "The document model must be unique")]
+    _sql_constraints = [
+        ("model_uniq", "unique (model_id)", "The document model must be unique")
+    ]
 
     @api.model
     def autocreate(self, inputs):
@@ -159,7 +169,12 @@ class EdiDocument(models.Model):
         states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
     state = fields.Selection(
-        [("draft", "New"), ("cancel", "Cancelled"), ("prep", "Prepared"), ("done", "Completed")],
+        [
+            ("draft", "New"),
+            ("cancel", "Cancelled"),
+            ("prep", "Prepared"),
+            ("done", "Completed"),
+        ],
         string="Status",
         readonly=True,
         index=True,
@@ -168,7 +183,11 @@ class EdiDocument(models.Model):
         tracking=True,
     )
     doc_type_id = fields.Many2one(
-        "edi.document.type", string="Document Type", required=True, readonly=True, index=True
+        "edi.document.type",
+        string="Document Type",
+        required=True,
+        readonly=True,
+        index=True,
     )
     prepare_date = fields.Datetime(string="Prepared on", readonly=True, copy=False)
     execute_date = fields.Datetime(string="Executed on", readonly=True, copy=False)
@@ -200,7 +219,9 @@ class EdiDocument(models.Model):
         domain=[("res_model", "=", "edi.document"), ("res_field", "=", "output_ids")],
         string="Output Attachments",
     )
-    input_count = fields.Integer(string="Input Count", compute="_compute_input_count", store=True)
+    input_count = fields.Integer(
+        string="Input Count", compute="_compute_input_count", store=True
+    )
     output_count = fields.Integer(
         string="Output Count", compute="_compute_output_count", store=True
     )
@@ -210,7 +231,9 @@ class EdiDocument(models.Model):
     issue_ids = fields.One2many(inverse_name="edi_doc_id")
 
     # Record type names (solely for use by views)
-    rec_type_names = fields.Char(string="Record Type Names", compute="_compute_rec_type_names")
+    rec_type_names = fields.Char(
+        string="Record Type Names", compute="_compute_rec_type_names"
+    )
 
     @api.depends("input_ids", "input_ids.res_id")
     def _compute_input_count(self):
@@ -325,7 +348,8 @@ class EdiDocument(models.Model):
             count = len(recs)
             if count:
                 _logger.info(
-                    "%s executed %s in %.2fs, %d records, %d queries " "(%d per record)",
+                    "%s executed %s in %.2fs, %d records, %d queries "
+                    "(%d per record)",
                     self.name,
                     RecModel._name,
                     stats.elapsed,
@@ -367,7 +391,9 @@ class EdiDocument(models.Model):
             return False
         # Mark as prepared
         self.state = "prep"
-        _logger.info("Prepared %s in %.2fs, %d queries", self.name, stats.elapsed, stats.count)
+        _logger.info(
+            "Prepared %s in %.2fs, %d queries", self.name, stats.elapsed, stats.count
+        )
         return True
 
     def action_unprepare(self):
@@ -379,7 +405,9 @@ class EdiDocument(models.Model):
         self.lock_for_action()
         # Check document state
         if self.state != "prep":
-            raise UserError(_("Cannot unprepare a %s document") % self._get_state_name())
+            raise UserError(
+                _("Cannot unprepare a %s document") % self._get_state_name()
+            )
         # Close any stale issues
         self.close_issues()
         # Delete any records
@@ -431,7 +459,9 @@ class EdiDocument(models.Model):
         # Mark as processed
         self.execute_date = fields.Datetime.now()
         self.state = "done"
-        _logger.info("Executed %s in %.2fs, %d queries", self.name, stats.elapsed, stats.count)
+        _logger.info(
+            "Executed %s in %.2fs, %d queries", self.name, stats.elapsed, stats.count
+        )
         return True
 
     def action_cancel(self):
@@ -514,7 +544,8 @@ class EdiDocumentModel(models.AbstractModel):
             return None
         if len(Models) != 1:
             raise ValueError(
-                _("Expected singleton record model: %s") % ",".join(x._name for x in Models)
+                _("Expected singleton record model: %s")
+                % ",".join(x._name for x in Models)
             )
         return Models[0]
 

--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -84,6 +84,11 @@ class EdiDocumentType(models.Model):
         default=True, string="Active", help="Display in list views or searches."
     )
 
+    # Optionally enforce filename globs
+    enforce_filename = fields.Boolean(string="Enforce Document Filenames",
+                                  help="Enforce document filenames follow glob pattern",
+                                  default=False)
+
     _sql_constraints = [("model_uniq", "unique (model_id)", "The document model must be unique")]
 
     @api.model

--- a/addons/edi/models/edi_synchronizer.py
+++ b/addons/edi/models/edi_synchronizer.py
@@ -255,7 +255,7 @@ class EdiSyncRecord(models.AbstractModel):
 
                 # Elide EDI records that are duplicates of earlier records
                 if produced is not None:
-                    frozen_record_vals = frozenset(record_vals.items())
+                    frozen_record_vals = frozenset((k, v) for k, v in record_vals.items() if not isinstance(v, models.NewId))
                     if frozen_record_vals in produced:
                         continue
                     produced.add(frozen_record_vals)

--- a/addons/edi/models/ir_attachment.py
+++ b/addons/edi/models/ir_attachment.py
@@ -19,7 +19,6 @@ class IrAttachment(models.Model):
         )
         for attachment in edi_document_attachments:
             doc = EdiDocument.browse(attachment.res_id)
-
             if doc.doc_type_id.enforce_filename:
                 recs = EdiGatewayPath.search(
                     [("doc_type_ids", "=", doc.doc_type_id.id)]
@@ -27,11 +26,12 @@ class IrAttachment(models.Model):
                 if recs:
                     globs = recs.mapped("glob")
                     for input in doc.input_ids:
-                        passed = False
-                        for glob in globs:
-                            if fnmatch.fnmatch(input.datas_fname, glob):
-                                passed = True
-                                break
+                        passed = bool(
+                            any(
+                                fnmatch.fnmatch(input.store_fname, glob)
+                                for glob in globs
+                            )
+                        )
                         if not passed:
                             raise ValidationError(
                                 _("Invalid filename when trying to attach.")

--- a/addons/edi/models/ir_attachment.py
+++ b/addons/edi/models/ir_attachment.py
@@ -1,0 +1,38 @@
+from odoo import api, models
+from odoo.exceptions import ValidationError
+from odoo.tools.translate import _
+
+import fnmatch
+
+
+class IrAttachment(models.Model):
+
+    _inherit = "ir.attachment"
+
+    @api.constrains("res_model")
+    def check_filename(self):
+        """Validates attachment filename against the format defined in 'glob'"""
+        EdiDocument = self.env["edi.document"]
+        EdiGatewayPath = self.env["edi.gateway.path"]
+        edi_document_attachments = self.filtered(
+            lambda a: a.res_model == "edi.document"
+        )
+        for attachment in edi_document_attachments:
+            doc = EdiDocument.browse(attachment.res_id)
+
+            if doc.doc_type_id.enforce_filename:
+                recs = EdiGatewayPath.search(
+                    [("doc_type_ids", "=", doc.doc_type_id.id)]
+                )
+                if recs:
+                    globs = recs.mapped("glob")
+                    for input in doc.input_ids:
+                        passed = False
+                        for glob in globs:
+                            if fnmatch.fnmatch(input.datas_fname, glob):
+                                passed = True
+                                break
+                        if not passed:
+                            raise ValidationError(
+                                _("Invalid filename when trying to attach.")
+                            )

--- a/addons/edi/views/edi_menu_views.xml
+++ b/addons/edi/views/edi_menu_views.xml
@@ -13,6 +13,10 @@
     <menuitem name="Records" id="record_menu" parent="root_menu"
 	      sequence="20"/>
 
+    <!-- Records/UDES menu -->
+    <menuitem id="record_udes_menu" name="UDES"
+	      parent="record_menu" sequence="30"/>
+
     <!-- Records SAP submenu -->
     <menuitem name="SAP" id="sap_menu" parent="record_menu"
 	      sequence="50"/>

--- a/addons/edi/views/edi_menu_views.xml
+++ b/addons/edi/views/edi_menu_views.xml
@@ -13,10 +13,6 @@
     <menuitem name="Records" id="record_menu" parent="root_menu"
 	      sequence="20"/>
 
-    <!-- Records/UDES menu -->
-    <menuitem id="record_udes_menu" name="UDES"
-	      parent="record_menu" sequence="30"/>
-
     <!-- Records SAP submenu -->
     <menuitem name="SAP" id="sap_menu" parent="record_menu"
 	      sequence="50"/>


### PR DESCRIPTION
Moved over functionality needed for edi item master interface. 

I changed where the UDES menu option is stored in UDES 14, in UDES 11 it was stored in udes_stock which felt wrong? 

Some of the EDI code in UDES 14/edi_record had been abstracted into another function, but it meant that you could not have multiple products with the same ref_id, so I changed it back to what it originally was in UDES 11. 