### PR TITLE
Story/929 [FIX] edi: Compute cron count as superuser to prevent permissions errors

### DIFF
--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -170,7 +170,7 @@ class EdiGateway(models.Model):
     cron_ids = fields.One2many(
         "ir.cron", "edi_gateway_id", domain=[("state", "=", "edi")], string="Schedule"
     )
-    cron_count = fields.Integer(string="Schedule Count", compute="_compute_cron_count")
+    cron_count = fields.Integer(string="Schedule Count", compute="_compute_cron_count", compute_sudo=True)
 
     @api.depends("model_id")
     def _compute_can_initiate(self):


### PR DESCRIPTION
Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 929