### PR TITLE
[FIX] odoo-edi: Move cancellation email now displays correct values

### DIFF
--- a/addons/edi_stock/data/edi_move_cancellation_data.xml
+++ b/addons/edi_stock/data/edi_move_cancellation_data.xml
@@ -48,7 +48,7 @@
             <div style="display:table-header-group;">
                 <div style="display:table-row;">
                     <div style="display:table-cell; padding: 0px 5px;">Part Number</div>
-                    <div style="display:table-cell; padding: 0px 5px;">Quantity Ordered</div>
+                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>
                     <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>
                 </div>
             </div>
@@ -57,13 +57,9 @@
                     <div style="display:table-row;">
                         <div style="display:table-cell; padding: 0px 5px;">${move.product_id.name_get()[0][1]}</div>
                         <div style="display:table-cell; padding: 0px 5px;">
-                            % if move.sale_line_id:
-                                ${move.sale_line_id.product_uom_qty}
-                            % else:
-                                ${move.product_uom_qty}
-                            % endif
+                            ${move.product_uom_qty}
                         </div>
-                        <div style="display:table-cell; padding: 0px 5px;">${move.write_uid.name}</div>
+                        <div style="display:table-cell; padding: 0px 5px;">${move.cancelled_by_id.name}</div>
                     </div>
                 % endfor
             </div>

--- a/addons/edi_stock/models/__init__.py
+++ b/addons/edi_stock/models/__init__.py
@@ -27,4 +27,5 @@ from . import edi_quant_report_record
 from . import edi_quant_report_tutorial
 from . import edi_route_document
 from . import edi_route_record
+from . import res_users
 from . import stock_picking

--- a/addons/edi_stock/models/edi_move_cancellation_report_document.py
+++ b/addons/edi_stock/models/edi_move_cancellation_report_document.py
@@ -20,6 +20,19 @@ class StockMove(models.Model):
         index=True,
     )
 
+    cancelled_by_id = fields.Many2one("res.users", string="Cancelled By", readonly=True)
+
+    def _action_cancel(self):
+        """
+        Set the cancelled_by_id to be the id of the user who cancels the move. This is 
+        needed to ensure that the user who cancels the pick is shown when the Move Cancellation
+        EDI document is created as before it would only show Admin user.
+        """
+        User = self.env["res.users"]
+
+        self.write({"cancelled_by_id": User.get_current_user_id()})
+        super()._action_cancel()
+
 
 class EdiDocument(models.Model):
     """Extend ``edi.document`` to include stock move cancellation records"""

--- a/addons/edi_stock/models/res_users.py
+++ b/addons/edi_stock/models/res_users.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+class Users(models.Model):
+    
+    _inherit = "res.users"
+
+    def get_current_user_id(self):
+        """
+        Returns the current user id.  
+        """
+        return self.env.uid

--- a/addons/edi_stock/tests/test_move_cancellation_report.py
+++ b/addons/edi_stock/tests/test_move_cancellation_report.py
@@ -84,7 +84,7 @@ class TestMoveCancellationReport(EdiPickCase):
             '            <div style="display:table-header-group;">',
             '                <div style="display:table-row;">',
             '                    <div style="display:table-cell; padding: 0px 5px;">Part Number</div>',
-            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Ordered</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>',
             '                    <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>',
             '                </div>',
             '            </div>',
@@ -92,7 +92,7 @@ class TestMoveCancellationReport(EdiPickCase):
             '                    <div style="display:table-row;">',
             '                        <div style="display:table-cell; padding: 0px 5px;">[BANANA] Banana</div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">',
-            '                                7.0',
+            '                            7.0',
             '                        </div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
             '                    </div>',
@@ -137,7 +137,7 @@ class TestMoveCancellationReport(EdiPickCase):
             '            <div style="display:table-header-group;">',
             '                <div style="display:table-row;">',
             '                    <div style="display:table-cell; padding: 0px 5px;">Part Number</div>',
-            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Ordered</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>',
             '                    <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>',
             '                </div>',
             '            </div>',
@@ -145,14 +145,14 @@ class TestMoveCancellationReport(EdiPickCase):
             '                    <div style="display:table-row;">',
             '                        <div style="display:table-cell; padding: 0px 5px;">[APPLE] Apple</div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">',
-            '                                5.0',
+            '                            5.0',
             '                        </div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
             '                    </div>',
             '                    <div style="display:table-row;">',
             '                        <div style="display:table-cell; padding: 0px 5px;">[BANANA] Banana</div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">',
-            '                                7.0',
+            '                            7.0',
             '                        </div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
             '                    </div>',
@@ -176,7 +176,7 @@ class TestMoveCancellationReport(EdiPickCase):
             '            <div style="display:table-header-group;">',
             '                <div style="display:table-row;">',
             '                    <div style="display:table-cell; padding: 0px 5px;">Part Number</div>',
-            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Ordered</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>',
             '                    <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>',
             '                </div>',
             '            </div>',
@@ -184,7 +184,7 @@ class TestMoveCancellationReport(EdiPickCase):
             '                    <div style="display:table-row;">',
             '                        <div style="display:table-cell; padding: 0px 5px;">[APPLE] Apple</div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">',
-            '                                9.0',
+            '                            9.0',
             '                        </div>',
             '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
             '                    </div>',
@@ -224,6 +224,72 @@ class TestMoveCancellationReport(EdiPickCase):
         )
         self.assertFalse(move_cancellation_reports2)
 
+    def _expected_mailbody_test04(self):
+        """Expected mail body for second email in test04
+        Split into function to allow ease of test extension in edi_sale_stock"""
+        return [
+            '<p>Products have been cancelled from <span style="font-weight: bold;">TEST</span> for the following customer:</p>',
+            '        <p>',
+            '                Administrator<br>',
+            '            The Tower of Art<br>Unseen University<br>Ankh-Morpork  <br></p>',
+            '        <h3>The following product(s) have been cancelled:</h3>',
+            '        <!-- Table is built in divs because Odoo WYSIWYG editor',
+            '            butchers for loops in tables if you edit & save the template -->',
+            '        <div style="display:table;">',
+            '            <div style="display:table-header-group;">',
+            '                <div style="display:table-row;">',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Part Number</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>',
+            '                </div>',
+            '            </div>',
+            '            <div style="display:table-row-group;">',
+            '                    <div style="display:table-row;">',
+            '                        <div style="display:table-cell; padding: 0px 5px;">[APPLE] Apple</div>',
+            '                        <div style="display:table-cell; padding: 0px 5px;">',
+            '                            5.0',
+            '                        </div>',
+            '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
+            '                    </div>',
+            '            </div>',
+            '        </div>',
+            '        ',
+            '            '
+        ]
+    
+    def _expected_mailbody2_test04(self):
+        """Expected mail body for second email in test04
+        Split into function to allow ease of test extension in edi_sale_stock"""
+        return [
+            '<p>Products have been cancelled from <span style="font-weight: bold;">TEST</span> for the following customer:</p>',
+            '        <p>',
+            '                Administrator<br>',
+            '            The Tower of Art<br>Unseen University<br>Ankh-Morpork  <br></p>',
+            '        <h3>The following product(s) have been cancelled:</h3>',
+            '        <!-- Table is built in divs because Odoo WYSIWYG editor',
+            '            butchers for loops in tables if you edit & save the template -->',
+            '        <div style="display:table;">',
+            '            <div style="display:table-header-group;">',
+            '                <div style="display:table-row;">',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Part Number</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Quantity Cancelled</div>',
+            '                    <div style="display:table-cell; padding: 0px 5px;">Cancelled By</div>',
+            '                </div>',
+            '            </div>',
+            '            <div style="display:table-row-group;">',
+            '                    <div style="display:table-row;">',
+            '                        <div style="display:table-cell; padding: 0px 5px;">[BANANA] Banana</div>',
+            '                        <div style="display:table-cell; padding: 0px 5px;">',
+            '                            7.0',
+            '                        </div>',
+            '                        <div style="display:table-cell; padding: 0px 5px;">Administrator</div>',
+            '                    </div>',
+            '            </div>',
+            '        </div>',
+            '        ',
+            '            '
+        ]
+
     def test04_partial_then_full_move_cancellation(self):
         """Test document brings in newly cancelled moves off the same pick
         when a report is run after each individual move cancellation"""
@@ -234,8 +300,11 @@ class TestMoveCancellationReport(EdiPickCase):
         moves_to_cancel._action_cancel()
         doc = self.create_and_execute_edi_doc("Move cancellation report test Apple")
         move_cancellation_reports = self.EdiMoveCancellationReport.search([("doc_id", "=", doc.id)])
+        cancellation_email_body_lines = move_cancellation_reports.sent_email_id.body_html.splitlines()
         self.assertTrue(len(move_cancellation_reports), 1)
         self.assertTrue(len(move_cancellation_reports.mapped("move_ids")), 1)
+        self.assertEqual(cancellation_email_body_lines, self._expected_mailbody_test04())
+
         # Cancel bananas off pick1
         moves_to_cancel2 = self.pick_out.move_lines.filtered(
             lambda move: move.product_id == self.banana
@@ -243,5 +312,7 @@ class TestMoveCancellationReport(EdiPickCase):
         moves_to_cancel2._action_cancel()
         doc2 = self.create_and_execute_edi_doc("Move cancellation report test Banana")
         move_cancellation_reports2 = self.EdiMoveCancellationReport.search([("doc_id", "=", doc2.id)])
+        cancellation_email_body_lines = move_cancellation_reports2.sent_email_id.body_html.splitlines()
         self.assertTrue(len(move_cancellation_reports2), 1)
         self.assertTrue(len(move_cancellation_reports2.mapped("move_ids")), 1)
+        self.assertEqual(cancellation_email_body_lines, self._expected_mailbody2_test04())


### PR DESCRIPTION
The quantity has been changed to quantity cancelled and the
"Cancelled By" column now has the correct user who cancelled the move.

User-story: 2168

Signed-off-by: Caleb Shelton <caleb.shelton@unipart.io>