### PR TITLE
[FIX] edi: Fix message_post to return ids when called from the deskto…

### DIFF
--- a/addons/edi/models/mail_thread.py
+++ b/addons/edi/models/mail_thread.py
@@ -12,6 +12,7 @@ class MailThread(models.AbstractModel):
 
     _inherit = "mail.thread"
 
+    @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *args, **kwargs):
         """Post message"""
         if self._context.get("tracking_disable"):


### PR DESCRIPTION
…p UI

task/5144

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

This follows the convention of other message_post definitions.