### PR TITLE
Set 143: sales order update via EDI

### DIFF
--- a/addons/edi_sale/models/edi_sale_line_request_record.py
+++ b/addons/edi_sale/models/edi_sale_line_request_record.py
@@ -74,6 +74,11 @@ class EdiSaleLineRequestRecord(models.Model):
 
     def execute(self):
         """Execute records"""
+        # Some subclasses also inherit 'edi.record.sync' and want to create/update via
+        # synchronizer. Don't create records in such cases.
+        if self._context.get("update_via_sync"):
+            return super().execute()
+
         ready = super().execute()
         SaleLine = self.env["sale.order.line"]
 


### PR DESCRIPTION
This is a draft MR; to make sure technical approach is sound. NOTE: yet to evaluate the suggestion to let synchronizer handle the sale line update process.