### PR TITLE
[FIX] edi: Remove dummy record types from tests.

### DIFF
--- a/addons/edi/tests/test_partner.py
+++ b/addons/edi/tests/test_partner.py
@@ -9,15 +9,11 @@ class TestPartner(EdiCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        EdiRecordType = cls.env["edi.record.type"]
         EdiDocumentType = cls.env["edi.document.type"]
         IrModel = cls.env["ir.model"]
-        cls.rec_type_partner = EdiRecordType.create(
-            {
-                "name": "Dummy partner record",
-                "model_id": IrModel._get_id("edi.partner.record"),
-            }
-        )
+
+        cls.rec_type_partner = cls.env.ref("edi.partner_record_type")
+
         cls.doc_type_partner = EdiDocumentType.create(
             {
                 "name": "Dummy partner document",
@@ -25,12 +21,8 @@ class TestPartner(EdiCase):
                 "rec_type_ids": [(6, 0, [cls.rec_type_partner.id])],
             }
         )
-        cls.rec_type_partner_title = EdiRecordType.create(
-            {
-                "name": "Dummy partner title record",
-                "model_id": IrModel._get_id("edi.partner.title.record"),
-            }
-        )
+        cls.rec_type_partner_title = cls.env.ref("edi.partner_title_record_type")
+
         cls.doc_type_partner_title = EdiDocumentType.create(
             {
                 "name": "Dummy partner title document",


### PR DESCRIPTION
SET-119-fixes

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

Dummy record types used in some tests cause problems with the cache clearance mechanism added in 26ebf02 as the code expects only one record in IrModel per EDI Record Type.

We will remove dummy record types that cause these errors from tests as it is not clear what value they add, beyond demonstrating the flexibility of the architecture.