### PR TITLE
[EDI] UDES-14 - Gateway menu is slow when lots of transfers

### DIFF
--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -192,9 +192,20 @@ class EdiGateway(models.Model):
 
     @api.depends("transfer_ids")
     def _compute_transfer_count(self):
-        """Compute number of transfers (for UI display)"""
+        """Compute number of transfers (for UI display)
+        We use the read_group method to aggregate data from the edi.transfer model.
+        We specify the search domain to filter transfers related to the current edi.gateway,
+        group the results by gateway_id, and count the number of records for each group."""
+
+        EdiTransfer = self.env["edi.transfer"]
+        transfers_data = EdiTransfer.read_group(
+            [("gateway_id", "in", self.ids)], ["gateway_id"], ["gateway_id"]
+        )
+        transfer_count_dict = {
+            data["gateway_id"][0]: data["gateway_id_count"] for data in transfers_data
+        }
         for gw in self:
-            gw.transfer_count = len(gw.transfer_ids)
+            gw.transfer_count = transfer_count_dict.get(gw.id, 0)
 
     @api.depends("doc_ids")
     def _compute_doc_count(self):


### PR DESCRIPTION
EDI gateway menu is slow down when lots of edi transfers happens. so it is resolved by improve the manage transfer.

Story :: SE-18

Signed off By :: vishal.vasoya@unipart.com