### PR TITLE
[FIX] edi: Remove unknown "tracking" parameter

### DIFF
--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -122,7 +122,6 @@ class EdiDocumentType(models.Model):
         "  This can be used to check that the file is syntactically correct."\
         "* Execute: automatically process, as if `allow_process` is True on `edi.transfer`.",
         copy=False,
-        tracking=True,
     )
     execute_sequentially = fields.Boolean(
         string="Sequential Execution Required", help="Document can only be processed if all "\


### PR DESCRIPTION
remove-edi-tracking-param

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

This seems to be a copy-paste error. `tracking` is a legitimate parameter on fields in models that inherit from `mail.thread`.