### PR TITLE
[TEST] edi: Add switch test files dir context manager

### DIFF
--- a/addons/edi/tests/common.py
+++ b/addons/edi/tests/common.py
@@ -191,7 +191,7 @@ class EdiCase(common.SavepointCase):
 
         # Delete the raised issue
         new_issue_ids.unlink()
-    
+
     @classmethod
     def _set_test_file_directory(cls, path):
         """
@@ -203,4 +203,16 @@ class EdiCase(common.SavepointCase):
         path = get_resource_path(module, "tests", path)
         if path:
             cls.files = pathlib.Path(path)
+
+    @classmethod
+    @contextmanager
+    def _temporary_test_file_directory(cls, path):
+        """Temporarily change path for test files."""
+        files = cls.files
+        try:
+            cls._set_test_file_directory(path)
+            yield
+        finally:
+            cls._set_test_file_directory(files)
+
 


### PR DESCRIPTION
SE-2020

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

Add a context manager to handle changing and reinstating the test files directory.  This allows us to round-trip request/report combinations more realistically.